### PR TITLE
examples: correct bundle classes

### DIFF
--- a/examples/IID1-dual-uart-module.mnfs
+++ b/examples/IID1-dual-uart-module.mnfs
@@ -44,7 +44,7 @@ protocol = 0x04
 
 ; Bundle 1
 [bundle-descriptor 1]
-class = 4
+class = 0x0a
 
 ; UART protocol on CPort 2
 [cport-descriptor 2]
@@ -53,4 +53,4 @@ protocol = 0x04
 
 ; Bundle 2
 [bundle-descriptor 2]
-class = 4
+class = 0x0a

--- a/examples/IID1-simple-audio-module.mnfs
+++ b/examples/IID1-simple-audio-module.mnfs
@@ -40,7 +40,7 @@ string = Simple Audio Interface
 ; I2S mgmt protocol on CPort 1
 [cport-descriptor 1]
 bundle = 1
-protocol = 0x0a
+protocol = 0x12
 
 ; I2S data reciever on CPort 2
 [cport-descriptor 2]
@@ -49,4 +49,4 @@ protocol = 0x12
 
 ; Bundle 1
 [bundle-descriptor 1]
-class = 0x0a 
+class = 0x12 

--- a/examples/IID1-simple-gpio-module.mnfs
+++ b/examples/IID1-simple-gpio-module.mnfs
@@ -44,4 +44,4 @@ protocol = 0x02
 
 ; Bundle 1
 [bundle-descriptor 1]
-class = 2
+class = 0x0a

--- a/examples/IID1-simple-i2c-module.mnfs
+++ b/examples/IID1-simple-i2c-module.mnfs
@@ -44,4 +44,4 @@ protocol = 0x03
 
 ; Bundle 1
 [bundle-descriptor 1]
-class = 3
+class = 0x0a

--- a/examples/IID1-simple-pwm-module.mnfs
+++ b/examples/IID1-simple-pwm-module.mnfs
@@ -44,4 +44,4 @@ protocol = 0x09
 
 ; Bundle 1
 [bundle-descriptor 1]
-class = 9
+class = 0x0a

--- a/examples/IID1-simple-sdio-module.mnfs
+++ b/examples/IID1-simple-sdio-module.mnfs
@@ -44,4 +44,4 @@ protocol = 0x07
 
 ; Bundle 1
 [bundle-descriptor 1]
-class = 7
+class = 0x0a

--- a/examples/IID1-simple-spi-module.mnfs
+++ b/examples/IID1-simple-spi-module.mnfs
@@ -44,4 +44,4 @@ protocol = 0x0b
 
 ; Bundle 1
 [bundle-descriptor 1]
-class = 11
+class = 0x0a

--- a/examples/IID1-simple-uart-module.mnfs
+++ b/examples/IID1-simple-uart-module.mnfs
@@ -44,4 +44,4 @@ protocol = 0x04
 
 ; Bundle 1
 [bundle-descriptor 1]
-class = 4
+class = 0x0a


### PR DESCRIPTION
Some of the example manifests had incorrect bundle classes and class 0x0a (bridged phy) should be used instead.

The warnings about the missing control descriptor are fine as the [control descriptors are optional](https://github.com/projectara/manifesto/blob/master/examples/IID1-simple-firmware-module.mnfs#L26).

pre:
```console
for mnfs in examples/*.mnfs; do \
        true \
        && echo ${mnfs} \
        && mnfb=`echo ${mnfs} | sed -e 's/\.mnfs/.mnfb/'` \
        && rm -f ${mnfb} \
        && ./manifesto -I mnfs -o ${mnfb} -O mnfb ${mnfs}; \
        if [ $? -ne 0 ]; then \
                exit 1; \
        fi; \
done
examples/IID1-dual-uart-module.mnfs
Warning: incompatible cport protocol 'UART' of '[cport-descriptor 1]' with class 'Reserved' of '[bundle-descriptor 1]'
Warning: incompatible cport protocol 'UART' of '[cport-descriptor 2]' with class 'Reserved' of '[bundle-descriptor 2]'
Warning: missing 'Control' cport
Warning: reserved class for '[bundle-descriptor 1]'
Warning: reserved class for '[bundle-descriptor 2]'
Warning: missing 'Control' bundle
examples/IID1-simple-audio-module.mnfs
Warning: reserved protocol for '[cport-descriptor 1]'
Warning: incompatible cport protocol 'Reserved' of '[cport-descriptor 1]' with class 'Bridged PHY' of '[bundle-descriptor 1]'
Warning: incompatible cport protocol 'Audio Management' of '[cport-descriptor 2]' with class 'Bridged PHY' of '[bundle-descriptor 1]'
Warning: missing 'Control' cport
Warning: missing 'Control' bundle
examples/IID1-simple-firmware-module.mnfs
examples/IID1-simple-gpio-module.mnfs
Warning: incompatible cport protocol 'GPIO' of '[cport-descriptor 1]' with class 'Reserved' of '[bundle-descriptor 1]'
Warning: reserved class for '[bundle-descriptor 1]'
examples/IID1-simple-i2c-module.mnfs
Warning: incompatible cport protocol 'I2C' of '[cport-descriptor 1]' with class 'Reserved' of '[bundle-descriptor 1]'
Warning: missing 'Control' cport
Warning: reserved class for '[bundle-descriptor 1]'
Warning: missing 'Control' bundle
examples/IID1-simple-lights-module.mnfs
examples/IID1-simple-loopback.mnfs
examples/IID1-simple-power-supply-module.mnfs
examples/IID1-simple-pwm-module.mnfs
Warning: incompatible cport protocol 'PWM' of '[cport-descriptor 1]' with class 'Reserved' of '[bundle-descriptor 1]'
Warning: missing 'Control' cport
Warning: reserved class for '[bundle-descriptor 1]'
Warning: missing 'Control' bundle
examples/IID1-simple-sdio-module.mnfs
Warning: incompatible cport protocol 'SDIO' of '[cport-descriptor 1]' with class 'Reserved' of '[bundle-descriptor 1]'
Warning: reserved class for '[bundle-descriptor 1]'
examples/IID1-simple-spi-module.mnfs
Warning: incompatible cport protocol 'SPI' of '[cport-descriptor 1]' with class 'Reserved' of '[bundle-descriptor 1]'
Warning: reserved class for '[bundle-descriptor 1]'
examples/IID1-simple-uart-module.mnfs
Warning: incompatible cport protocol 'UART' of '[cport-descriptor 1]' with class 'Reserved' of '[bundle-descriptor 1]'
Warning: missing 'Control' cport
Warning: reserved class for '[bundle-descriptor 1]'
Warning: missing 'Control' bundle
```

post:
```console
for mnfs in examples/*.mnfs; do \
        true \
        && echo ${mnfs} \
        && mnfb=`echo ${mnfs} | sed -e 's/\.mnfs/.mnfb/'` \
        && rm -f ${mnfb} \
        && ./manifesto -I mnfs -o ${mnfb} -O mnfb ${mnfs}; \
        if [ $? -ne 0 ]; then \
                exit 1; \
        fi; \
done
examples/IID1-dual-uart-module.mnfs
Warning: missing 'Control' cport
Warning: missing 'Control' bundle
examples/IID1-simple-audio-module.mnfs
Warning: missing 'Control' cport
Warning: missing 'Control' bundle
examples/IID1-simple-firmware-module.mnfs
examples/IID1-simple-gpio-module.mnfs
examples/IID1-simple-i2c-module.mnfs
Warning: missing 'Control' cport
Warning: missing 'Control' bundle
examples/IID1-simple-lights-module.mnfs
examples/IID1-simple-loopback.mnfs
examples/IID1-simple-power-supply-module.mnfs
examples/IID1-simple-pwm-module.mnfs
Warning: missing 'Control' cport
Warning: missing 'Control' bundle
examples/IID1-simple-sdio-module.mnfs
examples/IID1-simple-spi-module.mnfs
examples/IID1-simple-uart-module.mnfs
Warning: missing 'Control' cport
Warning: missing 'Control' bundle
```